### PR TITLE
Add hotfixes for various security vulnerabilities in Plone and Zope

### DIFF
--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -43,6 +43,7 @@ eggs =
     Products.PloneHotfix20110720
     Products.PloneHotfix20121106
     Products.PloneHotfix20130618==1.1
+    Products.Zope_Hotfix_CVE_2010_3198
     rhaptos.mathjax
     rhaptos.atompub.plone
     rhaptos.swordservice.plone

--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -39,7 +39,9 @@ eggs =
     Products.RhaptosSite
     Pillow
     demjson
+    Products.PloneHotfix20110531
     Products.PloneHotfix20110720
+    Products.PloneHotfix20121106
     rhaptos.mathjax
     rhaptos.atompub.plone
     rhaptos.swordservice.plone

--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -42,6 +42,7 @@ eggs =
     Products.PloneHotfix20110531
     Products.PloneHotfix20110720
     Products.PloneHotfix20121106
+    Products.PloneHotfix20130618==1.1
     rhaptos.mathjax
     rhaptos.atompub.plone
     rhaptos.swordservice.plone

--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -97,7 +97,7 @@ recipe = plone.recipe.zope2install
 fake-zope-eggs = true
 additional-fake-eggs = 
     ZODB3
-url = http://www.zope.org/Products/Zope/2.9.10/Zope-2.9.10-final.tgz
+url = http://www.zope.org/Products/Zope/2.9.12/Zope-2.9.12-final.tgz
 
 # Use this section to download additional old-style products.
 # List any number of URLs for product tarballs under URLs (separate


### PR DESCRIPTION
Adds Plone 2011-05-31, 2012-11-06, and 2013-06-18 security hotfixes. All patches apply fine on an empty devel install, except for the 2013-06-18 traverser and wysiwyg patches, which simply throw a warning that they cannot be applied and continues. 

The wysiwig patch does not apply to the version of kupu packaged with Plone 2.5.5.
The traverser patch only applies to Plone 3+.

Also, the Zope2 site has been down all week, so an alternative way to test 5b0c3f2 is to go into the buildout root and run:
`curl http://ftp.jp.netbsd.org/pub/pkgsrc/distfiles/Zope-2.9.12-final.tgz > downloads/Zope-2.9.12-final.tgz`

2.9.12 includes the fix for CVE-2010-1104

I also added a Zope hotfix for CVE-2010-3198