### PR TITLE
Change create rhaptos site script to look up site by id given

### DIFF
--- a/scripts/create_rhaptos_site.py
+++ b/scripts/create_rhaptos_site.py
@@ -50,9 +50,10 @@ def main(app, id, title, dbauser, dbuser, dbname, dbserver, dbport):
     app.virtual_hosting.set_map('http://*.cnx.rice.edu/ /'+id+'\nhttp://localhost/ /'+id)
 
     # Apply cnx.org styles
-    app.site.portal_setup.setImportContext(
+    site = getattr(app, id)
+    site.portal_setup.setImportContext(
         'profile-Products.CNXPloneSite:default')
-    app.site.portal_setup.manage_importSelectedSteps(
+    site.portal_setup.manage_importSelectedSteps(
         ['cnx_install'],
         True,  # run_dependencies
         app.REQUEST.RESPONSE)


### PR DESCRIPTION
It was hardcoded to get the object named "site", instead of using the id
that was used to create the site...