### PR TITLE
Use libxml2 2.7.8 instead of 2.7.6 in buildout.cfg

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -33,7 +33,7 @@ configure-options = --prefix=${buildout:directory}/parts/zlibg
 [libxml2]
 
 recipe = zc.recipe.cmmi
-url = http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.7.6.dfsg.orig.tar.gz
+url = http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.7.8.dfsg.orig.tar.gz
 configure-options = --with-python=${buildout:directory}/bin/python --with-zlib=${buildout:directory}/parts/zlibg --prefix=${buildout:directory}/parts/libxml2
 
 [libxslt]


### PR DESCRIPTION
```
libxml2: Downloading http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.7.6.dfsg.orig.tar.gz
While:
  Installing libxml2.

An internal error occured due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/var/lib/cnx/cnx-buildout/eggs/zc.buildout-1.4.4-py2.4.egg/zc/buildout/buildout.py", line 1683, in main
    getattr(buildout, command)(args)
  File "/var/lib/cnx/cnx-buildout/eggs/zc.buildout-1.4.4-py2.4.egg/zc/buildout/buildout.py", line 555, in install
    installed_files = self[part]._call(recipe.install)
  File "/var/lib/cnx/cnx-buildout/eggs/zc.buildout-1.4.4-py2.4.egg/zc/buildout/buildout.py", line 1227, in _call
    return f()
  File "build/bdist.linux-x86_64/egg/zc/recipe/cmmi/__init__.py", line 113, in install
  File "build/bdist.linux-x86_64/egg/zc/recipe/cmmi/__init__.py", line 134, in build
  File "/var/lib/cnx/cnx-buildout/eggs/zc.buildout-1.4.4-py2.4.egg/zc/buildout/download.py", line 94, in __call__
    local_path, is_temp = self.download_cached(url, md5sum)
  File "/var/lib/cnx/cnx-buildout/eggs/zc.buildout-1.4.4-py2.4.egg/zc/buildout/download.py", line 139, in download_cached
    _, is_temp = self.download(url, md5sum, cached_path)
  File "/var/lib/cnx/cnx-buildout/eggs/zc.buildout-1.4.4-py2.4.egg/zc/buildout/download.py", line 173, in download
    tmp_path, headers = urllib.urlretrieve(url, tmp_path)
  File "/usr/local/lib/python2.4/urllib.py", line 89, in urlretrieve
    return _urlopener.retrieve(url, filename, reporthook, data)
  File "/usr/local/lib/python2.4/urllib.py", line 222, in retrieve
    fp = self.open(url, data)
  File "/usr/local/lib/python2.4/urllib.py", line 190, in open
    return getattr(self, name)(url)
  File "/usr/local/lib/python2.4/urllib.py", line 322, in open_http
    return self.http_error(url, fp, errcode, errmsg, headers)
  File "/usr/local/lib/python2.4/urllib.py", line 339, in http_error
    return self.http_error_default(url, fp, errcode, errmsg, headers)
  File "/usr/local/lib/python2.4/urllib.py", line 345, in http_error_default
    raise IOError, ('http error', errcode, errmsg, headers)
IOError: ('http error', 404, 'Not Found', <httplib.HTTPMessage instance at 0x2439170>)
```

Close #9