### PR TITLE
Daemonize build zodb script properly by forking twice

### DIFF
--- a/scripts/build_zodb_from_postgres.py
+++ b/scripts/build_zodb_from_postgres.py
@@ -37,13 +37,13 @@ def build_zodb(root_url, db_conn):
     cursor.close()
 
 
-def main(root_url, fork=True):
+def main(root_url, daemonize=False):
     db_conn = app.plone.objectValues('Z Psycopg 2 Database Connection')
     if len(db_conn) == 0:
         sys.stderr.write('No database connection object found')
         sys.exit(1)
 
-    if fork:
+    if daemonize:
         pid = os.fork()
         if pid:
             # Parent process exits.
@@ -74,9 +74,9 @@ def main(root_url, fork=True):
 if __name__ == '__main__':
     usage = 'Usage: %prog [options] root_url'
     parser = OptionParser(usage=usage)
-    parser.add_option('--no-fork', dest='to_fork',
-                      action='store_false', default=True,
-                      help='Not fork the process (default true)')
+    parser.add_option('-d', dest='daemonize',
+                      action='store_true', default=False,
+                      help='Run this script as a background job (daemonize)')
     options, args = parser.parse_args()
 
     if len(args) != 1:
@@ -84,4 +84,4 @@ if __name__ == '__main__':
         parser.print_help()
         sys.exit(1)
 
-    main(args[0], fork=options.to_fork)
+    main(args[0], daemonize=options.daemonize)


### PR DESCRIPTION
When the build zodb script was called from ansible, it was terminated
when ansible moves on to the next step.

This change decouples the process from the calling terminal so it can
run on its own, even if that terminal is closed.