### PR TITLE
Set $HOME environment variable when running `make module.pdf`

### DIFF
--- a/scripts/module2pdf.sh
+++ b/scripts/module2pdf.sh
@@ -27,7 +27,7 @@ if [ "." != ".${PRINT_STYLE}" ]; then
 else
 
   cp $MAKEFILE Makefile
-  make -e module.pdf > log.txt
+  HOME=$PWD make -e module.pdf > log.txt
   cat module.log >> log.txt
   cat module.mxt >> log.txt
   ls -al * >> log.txt


### PR DESCRIPTION
This is the error:

```
kpathsea: Running mktexpk --mfmode / --bdpi 600 --mag 1+0/600 --dpi 600 ecrm0600
mktexpk: /usr/share/texlive/texmf-dist/web2c/mktexdir ./.texmf-var/fonts/pk/ljfour/jknappen/ec failed.
kpathsea: Appending font creation commands to missfont.log.
make: [module.pdf] Error 1 (ignored)
make: [module.pdf] Error 2 (ignored)
```

This command usually creates fonts in the home directory but the
environment doesn't have a home directory set, causing some weird
problems.