### PR TITLE
Split the library configuration into a separate config

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,6 +6,7 @@ overwrite-picked-versions-file = true
 
 extends =
     base.cfg
+    libs.cfg
     sources.cfg
 
 auto-checkout = *
@@ -24,28 +25,3 @@ parts +=
 [instance]
 debug-mode = on
 verbose-security = on
-
-[zlibg]
-recipe = zc.recipe.cmmi
-url = http://us.archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib_1.2.3.4.dfsg.orig.tar.gz
-configure-options = --prefix=${buildout:directory}/parts/zlibg
-
-[libxml2]
-
-recipe = zc.recipe.cmmi
-url = http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.7.8.dfsg.orig.tar.gz
-configure-options = --with-python=${buildout:directory}/bin/python --with-zlib=${buildout:directory}/parts/zlibg --prefix=${buildout:directory}/parts/libxml2
-
-[libxslt]
-recipe = zc.recipe.cmmi
-url = http://archive.ubuntu.com/ubuntu/pool/main/libx/libxslt/libxslt_1.1.26.orig.tar.gz
-configure-options = --with-python=${buildout:directory}/bin/python --prefix=${buildout:directory}/parts/libxslt
-extra_options = --with-libxml-prefix=${buildout:directory}/parts/libxml2/
-
-[xmlxsl-links] 
-recipe = iw.recipe.cmd
-on_install = true
-on_update = false
-cmds = ln -sf ${buildout:directory}/parts/libxml2/bin/* ${buildout:directory}/bin
-       ln -sf ${buildout:directory}/parts/libxslt/bin/* ${buildout:directory}/bin
-       echo "export LD_PRELOAD=${buildout:directory}/parts/zlibg/lib/libz.so:${buildout:directory}/parts/libxml2/lib/libxml2.so:${buildout:directory}/parts/libxslt/lib/libxslt.so:${buildout:directory}/parts/libxslt/lib/libexslt.so" > bin/libs.sh

--- a/libs.cfg
+++ b/libs.cfg
@@ -1,0 +1,23 @@
+[zlibg]
+recipe = zc.recipe.cmmi
+url = http://us.archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib_1.2.3.4.dfsg.orig.tar.gz
+configure-options = --prefix=${buildout:directory}/parts/zlibg
+
+[libxml2]
+recipe = zc.recipe.cmmi
+url = http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.7.8.dfsg.orig.tar.gz
+configure-options = --with-python=${buildout:directory}/bin/python --with-zlib=${buildout:directory}/parts/zlibg --prefix=${buildout:directory}/parts/libxml2
+
+[libxslt]
+recipe = zc.recipe.cmmi
+url = http://archive.ubuntu.com/ubuntu/pool/main/libx/libxslt/libxslt_1.1.26.orig.tar.gz
+configure-options = --with-python=${buildout:directory}/bin/python --prefix=${buildout:directory}/parts/libxslt
+extra_options = --with-libxml-prefix=${buildout:directory}/parts/libxml2/
+
+[xmlxsl-links] 
+recipe = iw.recipe.cmd
+on_install = true
+on_update = false
+cmds = ln -sf ${buildout:directory}/parts/libxml2/bin/* ${buildout:directory}/bin
+       ln -sf ${buildout:directory}/parts/libxslt/bin/* ${buildout:directory}/bin
+       echo "export LD_PRELOAD=${buildout:directory}/parts/zlibg/lib/libz.so:${buildout:directory}/parts/libxml2/lib/libxml2.so:${buildout:directory}/parts/libxslt/lib/libxslt.so:${buildout:directory}/parts/libxslt/lib/libexslt.so" > bin/libs.sh

--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -26,7 +26,6 @@ parts =
 find-links =
     http://pypi.rhaptos.org
     http://dist.rhaptos.org/simple
-    http://dist.enfoldsystems.com/simple
     http://public.upfronthosting.co.za/eggs
     https://downloads.egenix.com/python/index/ucs4/
     http://effbot.org/media/downloads/elementtree-1.2.7-20070827-preview.zip


### PR DESCRIPTION
The library buildout config was pulled into a separate file so that we can reuse it in an ansible specific configuration. I'll link that pull request to this one when it's been created.

Also, this removes the enfold systems url, which eventually times out.