### PR TITLE
use jpegoptim to strip all tags from JPEGs 

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,7 +28,7 @@ echo "deb http://us.archive.ubuntu.com/ubuntu/ hardy main" >/etc/apt/sources.lis
 apt-get update
 
 apt-get install postgresql postresql-contrib libpq-dev openjdk-7-jre-headless
-apt-get install python2.4-dev python-virtualenv make git libjpeg-dev libpng-dev build-essential
+apt-get install python2.4-dev python-virtualenv make git libjpeg-dev libpng-dev build-essential jpegoptim
 
 Modify postgresql config to allow trusted access on local domain sockets:
 

--- a/scripts/collection2pdf.sh
+++ b/scripts/collection2pdf.sh
@@ -33,6 +33,9 @@ else
 fi
 mv ${COLLECTION_ID}_${COLLECTION_VERSION}_complete/* . && rm -rf ${COLLECTION_ID}_${COLLECTION_VERSION}_complete
 
+echo "Optimizing JPEGs - deleting excess tags"
+find . -type f -exec file {} \; | awk -F: '{if ($2 ~/JPEG/) print $1}'| while read f; do  jpegoptim --strip-all $f; done
+
 PRINT_STYLE=$(${XSLTPROC} ${PRINT_STYLE_XSL} collection.xml)
 
 if [ "." != ".${PRINT_STYLE}" ]; then


### PR DESCRIPTION
This will minimize size of the resulting PDF (using docbook/prince pipeline). Some jpegs are as much as 95% tags (apparently uncompressed 'preview' image)