### PR TITLE
Use the current executable to define PYTHON for pdf generation

### DIFF
--- a/scripts/create_collection_pdf.zctl
+++ b/scripts/create_collection_pdf.zctl
@@ -54,6 +54,7 @@ if dictRequest is not None:
 
         env = os.environ
         # override the makefile default values via environment variables and '-e' switch
+        env['PYTHON'] = sys.executable
         env['PRINT_DIR'] = printdir
         env['HOST'] = host
         env['COLLECTION_ID'] = collectionId


### PR DESCRIPTION
The new environment setup needs access to the virtualenv executable rather than the default `PYTHON=/usr/bin/env python2.4` defined in the `course_print.mak` file.