### PR TITLE
Specify the output format as ODT for ooconvert_unoconv.sh

### DIFF
--- a/scripts/ooconvert_unoconv.sh
+++ b/scripts/ooconvert_unoconv.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # We're discarding the rest of the params that are sent
-"${BASH_SOURCE[0]%/*}/unoconv" --stdout --format=odt "$1"
+"${BASH_SOURCE[0]%/*}/unoconv" --stdout --format=sxw "$1"

--- a/scripts/ooconvert_unoconv.sh
+++ b/scripts/ooconvert_unoconv.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # We're discarding the rest of the params that are sent
-"${BASH_SOURCE[0]%/*}/unoconv" --stdout "$1"
+"${BASH_SOURCE[0]%/*}/unoconv" --stdout --format=odt "$1"


### PR DESCRIPTION
The `ooconvert_unoconv.sh` was defaulting to outputting a PDF.

