### PR TITLE
make ooconvert_unoconv.sh immune to virtualenv

### DIFF
--- a/scripts/ooconvert_unoconv.sh
+++ b/scripts/ooconvert_unoconv.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 # We're discarding the rest of the params that are sent
-python3 /usr/local/bin/unoconv --stdout --format=odt "$1"
+unset PYTHONPATH
+/usr/bin/unoconv --stdout --format=odt "$1"

--- a/scripts/oolaunch
+++ b/scripts/oolaunch
@@ -3,4 +3,4 @@
 # sudo su www-data ./oolaunch
 # Going to default this to using unoconv
 
-python3 /usr/local/bin/unoconv -l &
+/usr/bin/unoconv -l &


### PR DESCRIPTION
need to unset PYTHONPATH so python3 can find its own libraries.