### PR TITLE
Update LocalFS set up script to take a list

### DIFF
--- a/scripts/set_up_localfs_for_pdfs.py
+++ b/scripts/set_up_localfs_for_pdfs.py
@@ -1,19 +1,43 @@
+import sys
+
 from Products.CMFCore.utils import getToolByName
 import transaction
 
 
-def main(site):
-    if hasattr(site, 'pdfs'):
-        site._delObject('pdfs')
-    # Store pdfs in /var/www/files
-    site.manage_addProduct['LocalFS'].manage_addLocalFS(
-        id='pdfs', title='pdf-storage', basepath='/var/www/files')
+def main(site, paths):
+    # paths should be in the format
+    #  ["pdfs:/var/www/files", "pdfs2:/var/www/files2", ...]
+    storage_paths = []
+    for path in paths:
+        obj_name, file_path = path.split(':', 1)
+        if hasattr(site, obj_name):
+            site._delObject(obj_name)
+        site.manage_addProduct['LocalFS'].manage_addLocalFS(
+            id=obj_name, title='pdf-storage', basepath=file_path)
+        storage_paths.append(obj_name)
+
     # Use the local fs object in print tool
     ptool = getToolByName(site, 'rhaptos_print')
-    ptool.storagePaths = ptool.DEFAULT_STORAGE_PATHS
+    ptool.storagePaths = storage_paths
     ptool.storagePath = ptool.storagePaths[0]
     transaction.commit()
 
 
+def print_help_and_exit():
+    sys.stderr.write("""\
+Usage: %s <object_name>:<path_to_local_dir> ...
+
+Example: %s pdfs:/var/www/files
+""" % (sys.argv[0], sys.argv[0]))
+    sys.exit(1)
+
+
 if __name__ == '__main__':
-    main(app.plone)
+    if len(sys.argv) < 2:
+        print_help_and_exit()
+    paths = sys.argv[1:]
+    for path in paths:
+        if ':' not in path:
+            sys.stderr.write('Error: ":" missing in %s\n' % path)
+            print_help_and_exit()
+    main(app.plone, paths)


### PR DESCRIPTION
The object name and directory path were hardcoded in the script.  We
need to be able to pass in that information from the command line.

Running the following command

```
./bin/instance run scripts/set_up_localfs_for_pdfs.py pdfs:/var/www/files pdfs2:/var/www/files2
```

will create 2 "LocalFS" objects in the plone site called "pdfs" and
"pdfs2", pointing to /var/www/files and /var/www/files2 in the
filesystem respectively.