### PR TITLE
Change collection2pdf to look in /var/www/files* for complete zip

### DIFF
--- a/scripts/collection2pdf.sh
+++ b/scripts/collection2pdf.sh
@@ -18,7 +18,7 @@
 
 XSLTPROC=xsltproc
 PRINT_STYLE_XSL=${EPUB_DIR}/xsl/collxml-print-style.xsl
-FILESTORE=/var/www/files
+FILESTORE=/var/www/files*
 
 
 


### PR DESCRIPTION
We added a new NFS server and mounted it at /var/www/files3 so the
script was unable to look for the complete zip.