### PR TITLE
Check existence of latest zip in collection2pdf.sh

### DIFF
--- a/scripts/collection2pdf.sh
+++ b/scripts/collection2pdf.sh
@@ -22,14 +22,14 @@ FILESTORE=/var/www/files*
 
 
 
-COMPLETENAME=${FILESTORE}/${COLLECTION_ID}-${COLLECTION_VERSION}.complete.zip
+COMPLETENAME=$(ls -t ${FILESTORE}/${COLLECTION_ID}-${COLLECTION_VERSION}.complete.zip | head -1)
 
 if [ -e $COMPLETENAME ]; then
     echo "Found complete zip in filestore"
     unzip -o $COMPLETENAME
 else
     echo "Downloading and unzipping the complete zip"
-    wget --timeout=300 -O complete.zip ${HOST}/content/${COLLECTION_ID}/${COLLECTION_VERSION}/complete && unzip complete.zip 
+    wget --timeout=300 -O complete.zip ${HOST}/content/${COLLECTION_ID}/${COLLECTION_VERSION}/complete && unzip -o complete.zip
 fi
 mv ${COLLECTION_ID}_${COLLECTION_VERSION}_complete/* . && rm -rf ${COLLECTION_ID}_${COLLECTION_VERSION}_complete
 
@@ -48,13 +48,12 @@ if [ "." != ".${PRINT_STYLE}" ]; then
 else
   echo "Running old-style PDF generation using latex"
 
-  COMPLETENAME=${FILESTORE}/${COLLECTION_ID}-${COLLECTION_VERSION}.complete.zip
   if [ -e $COMPLETENAME ]; then
     echo "Found complete zip in filestore"
     unzip -o $COMPLETENAME
   else
     echo "Downloading and unzipping the complete zip"
-    wget --timeout=300 -O complete.zip ${HOST}/content/${COLLECTION_ID}/${COLLECTION_VERSION}/complete && unzip complete.zip 
+    wget --timeout=300 -O complete.zip ${HOST}/content/${COLLECTION_ID}/${COLLECTION_VERSION}/complete && unzip -o complete.zip
   fi
 
   mv ${COLLECTION_ID}_${COLLECTION_VERSION}_complete/* . && rm -rf ${COLLECTION_ID}_${COLLECTION_VERSION}_complete


### PR DESCRIPTION
On prod, we are seeing the same files in more than one files storage:

```
$ ls -l /var/www/files*/col11790-1.1.complete.zip
-rw-r--r--  1 www-data www-data 431989978 Aug 25 04:59 /var/www/files3/col11790-1.1.complete.zip
-rw-r--r-- 78 www-data www-data 431989978 Aug  2 17:53 /var/www/files/col11790-1.1.complete.zip
```

This causes the following error message when executing `if [ -e $COMPLETENAME ]; then`:

```
/var/lib/cnx/cnx-buildout/scripts/collection2pdf.sh: 27: [: /var/www/files/col11790-1.1.complete.zip: unexpected operator
```

To fix this, we are putting only the latest file in `$COMPLETENAME`, instead of
leaving the wildcard match to return potentially more than one file.

The code then goes on and tries to wget the zip file and unzip it.  The next
error comes when we do `unzip complete.zip`:

```
--2017-08-25 05:18:35--  http://cnx.org/content/col11790/1.1/complete
Resolving cnx.org (cnx.org)... 128.42.169.27
Connecting to cnx.org (cnx.org)|128.42.169.27|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 431989978 (412M) [application/zip]
Saving to: ‘complete.zip’

2017-08-25 05:18:46 (41.2 MB/s) - ‘complete.zip’ saved [431989978/431989978]

replace col11790_1.1_complete/m42119/index_auto_generated.cnxml? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

Our complete zip for some reason has 2 index_auto_generated.cnxml files for
some modules.  For example:

```
Archive:  /var/www/files/col11407-1.7.complete.zip
    testing: col11407_1.7_complete/collection.xml   OK
    testing: col11407_1.7_complete/m42789/index_auto_generated.cnxml   OK
    testing: col11407_1.7_complete/m42789/Figure_01_01_01b.jpg   OK
    testing: col11407_1.7_complete/m42789/Figure_01_01_02a.jpg   OK
    testing: col11407_1.7_complete/m42789/index_auto_generated.cnxml   OK
    testing: col11407_1.7_complete/m42789/index.cnxml   OK
    testing: col11407_1.7_complete/m42789/index.cnxml.html   OK
```

To fix this, we need to use `unzip -o` to overwrite existing files.