### PR TITLE
Change bootstrap.py to specify https pypi index url

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -107,7 +107,8 @@ if is_jython:
 else:
     assert os.spawnle(
         os.P_WAIT, sys.executable, quote (sys.executable),
-        '-c', quote (cmd), '-mqNxd', quote (tmpeggs), 'zc.buildout' + VERSION,
+        '-c', quote (cmd), '-mqNxd', quote (tmpeggs),
+        '-i', 'https://pypi.python.org/simple', 'zc.buildout' + VERSION,
         dict(os.environ,
             PYTHONPATH=
             ws.find(pkg_resources.Requirement.parse(requirement)).location


### PR DESCRIPTION
When installing zc.buildout, bootstrap.py uses setuptools easy_install
to install the package.  If an index url is not given, it defaults to
`http://pypi.python.org/simple`.  But it is returning this error:

```
Couldn't find index page for 'zc.buildout' (maybe misspelled?)
No local packages or download links found for zc.buildout==1.4.3
Traceback (most recent call last):
  File "<string>", line 1, in ?
  File "/var/cnx/venvs/cnx-buildout/lib/python2.4/site-packages/setuptools-0.6c11-py2.4.egg/setuptools/command/easy_install.py", line 1712, in main
    with_ei_usage(lambda:
  File "/var/cnx/venvs/cnx-buildout/lib/python2.4/site-packages/setuptools-0.6c11-py2.4.egg/setuptools/command/easy_install.py", line 1700, in with_ei_usage
    return f()
  File "/var/cnx/venvs/cnx-buildout/lib/python2.4/site-packages/setuptools-0.6c11-py2.4.egg/setuptools/command/easy_install.py", line 1716, in <lambda>
    distclass=DistributionWithoutHelpCommands, **kw
  File "/usr/local/lib/python2.4/distutils/core.py", line 149, in setup
    dist.run_commands()
  File "/usr/local/lib/python2.4/distutils/dist.py", line 946, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python2.4/distutils/dist.py", line 966, in run_command
    cmd_obj.run()
  File "/var/cnx/venvs/cnx-buildout/lib/python2.4/site-packages/setuptools-0.6c11-py2.4.egg/setuptools/command/easy_install.py", line 211, in run
    self.easy_install(spec, not self.no_deps)
  File "/var/cnx/venvs/cnx-buildout/lib/python2.4/site-packages/setuptools-0.6c11-py2.4.egg/setuptools/command/easy_install.py", line 434, in easy_install
    self.local_index
  File "/var/cnx/venvs/cnx-buildout/lib/python2.4/site-packages/setuptools-0.6c11-py2.4.egg/setuptools/package_index.py", line 475, in fetch_distribution
    return dist.clone(location=self.download(dist.location, tmpdir))
AttributeError: 'NoneType' object has no attribute 'clone'
Traceback (most recent call last):
  File "bootstrap.py", line 119, in ?
    PYTHONPATH=
AssertionError
```

The reason seems to be that pypi recently enforces https.  For example using
`wget` on a http pypi url, we get a "SSL is required" error:

```
$ wget -O - 'http://pypi.python.org/simple/zc.buildout'
--2017-10-27 17:31:06--  http://pypi.python.org/simple/zc.buildout
Resolving pypi.python.org (pypi.python.org)... 151.101.0.223, 151.101.64.223, 151.101.128.223, ...
Connecting to pypi.python.org (pypi.python.org)|151.101.0.223|:80... connected.
HTTP request sent, awaiting response... 403 SSL is required
2017-10-27 17:31:06 ERROR 403: SSL is required.
```

The simplest change is to just add a https pypi index url for setuptools
so it installs zc.buildout.