### PR TITLE
Update rhaptos-base.cfg index url to https pypi

### DIFF
--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -31,7 +31,7 @@ find-links =
     https://downloads.egenix.com/python/index/ucs4/
     http://effbot.org/media/downloads/elementtree-1.2.7-20070827-preview.zip
 
-# index = http://pypi.rhaptos.org
+index = https://pypi.python.org/simple/
 
 eggs-directory = ${buildout:directory}/eggs
 


### PR DESCRIPTION
Pypi does not allow http access anymore, and easy install doesn't seem
to follow redirects so we need to explicitly set the index url to
https://pypi.python.org/simple/ for buildout to work.