### PR TITLE
Add https pypi as the index url for pip installs in rhaptos-base.cfg

### DIFF
--- a/rhaptos-base.cfg
+++ b/rhaptos-base.cfg
@@ -430,10 +430,10 @@ recipe = iw.recipe.cmd
 on_install = true
 on_update = false
 cmds =
-    pip install --no-install egenix-mx-base==3.2.5
-    pip install --no-install --build=./build psycopg2==2.4.6
+    pip install -i https://pypi.python.org/simple/ --no-install egenix-mx-base==3.2.5
+    pip install -i https://pypi.python.org/simple/ --no-install --build=./build psycopg2==2.4.6
     sed -i 's;#mx_include_dir=;mx_include_dir=${buildout:directory}/parts/egenix-source/mx/DateTime/mxDateTime/;' ${buildout:directory}/build/psycopg2/setup.cfg
-    pip install --no-download --build=./build psycopg2
+    pip install -i https://pypi.python.org/simple/ --no-download --build=./build psycopg2
     
 # requires python-egenix-mx-base-dev and libpq-dev system packages
 [psycopg1]


### PR DESCRIPTION
Pypi no longer accept http urls so we get errors like this when running
buildout:

```
Updating psycopg2.
Downloading/unpacking psycopg2==2.4.6
  Cannot fetch index base URL http://pypi.python.org/simple/
  Could not find any downloads that satisfy the requirement psycopg2==2.4.6
No distributions at all found for psycopg2==2.4.6
Storing complete log in /root/.pip/pip.log
sed: can't read /var/lib/cnx/cnx-buildout/build/psycopg2/setup.cfg: No such file or directory
Could not install requirement psycopg2 because source folder /var/lib/cnx/cnx-buildout/build/psycopg2 does not exist (perhaps --no-download was used without first running an equivalent install with --no-install?)
Storing complete log in /root/.pip/pip.log
```