### PR TITLE
Change update_users_passwds_roles to find db connection by type

### DIFF
--- a/scripts/addRhaptosUser.zctl
+++ b/scripts/addRhaptosUser.zctl
@@ -9,10 +9,10 @@ from Products.CMFCore.utils import getToolByName
 def add_a_user(type,username,password,firstname,surname,email):
 
     if type == 'org':
-        groups = ('Member','Endorser','Publisher')
+        groups = ('Member','Endorser','Publisher', 'Maintainer')
         newprops = { 'fullname':firstname, 'shortname':surname, 'email':email, 'account_type':'org', 'status':'Approved' }
     elif type == 'manager':
-        groups = ('Member','Manager','Publisher')
+        groups = ('Member','Manager','Publisher', 'Maintainer')
         fullname = "%s %s" % (firstname,surname)
         newprops = { 'firstname':firstname, 'surname':surname, 'email':email, 'fullname':fullname, 'status':'Approved' }
     elif type == 'new':
@@ -20,7 +20,7 @@ def add_a_user(type,username,password,firstname,surname,email):
         fullname = "%s %s" % (firstname,surname)
         newprops = { 'firstname':firstname, 'surname':surname, 'email':email, 'fullname':fullname, 'status':'Approved' }
     else:
-        groups = ('Member','Publisher')
+        groups = ('Member','Publisher', 'Maintainer')
         fullname = "%s %s" % (firstname,surname)
         newprops = { 'firstname':firstname, 'surname':surname, 'email':email, 'fullname':fullname, 'status':'Approved' }
 

--- a/scripts/addRhaptosUser.zctl
+++ b/scripts/addRhaptosUser.zctl
@@ -58,6 +58,14 @@ mdtool = getToolByName(portal, 'portal_memberdata')
 user_folder = getToolByName(portal, 'acl_users')
 member_ids = mdtool.objectIds()
 
+# make all portal roles assignable
+from Products.PluggableAuthService.interfaces.plugins import IRoleAssignerPlugin
+role_assigner = app.plone.acl_users.plugins.listPlugins(IRoleAssignerPlugin)[0][1]
+assignable_roles = list(role_assigner.listRoleIds())
+for role in mtool.getPortalRoles():
+    if role not in assignable_roles:
+        role_assigner.addRole(role)
+
 if len(sys.argv) == 7:
     type       = sys.argv[1]
     username   = sys.argv[2]

--- a/scripts/update_users_passwds_roles.py
+++ b/scripts/update_users_passwds_roles.py
@@ -33,7 +33,7 @@ def main(app):
     app = makerequest(app)
 
     # Grab connection to db
-    db = app.devrep()
+    db = app.plone.objectValues('Z Psycopg 2 Database Connection')[0]()
 
     # Get all users who have extended roles
     updates = 0


### PR DESCRIPTION
update_users_passwds_roles.py was using `app.devrep()` to create a
database connection, which doesn't exist on the servers we ran this
script (the `devrep` object doesn't exist).

Instead, find "Z Psycopg 2 Database Connection" under the plone site:

```
app.plone.objectValues('Z Psycopg 2 Database Connection')[0]()
```

This should create a database even if the object has been renamed.

---

Part of https://github.com/openstax/cnx/issues/736 and https://github.com/openstax/cnx/issues/691