### PR TITLE
Fix bootstrap.py to detect setuptools correctly

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -56,8 +56,10 @@ args = args + ['bootstrap']
 to_reload = False
 try:
     import pkg_resources
-    if not hasattr(pkg_resources, '_distribute'):
-        to_reload = True
+    to_reload = True
+    if not USE_DISTRIBUTE:
+        import setuptools
+    elif not hasattr(pkg_resources, '_distribute'):
         raise ImportError
 except ImportError:
     ez = {}


### PR DESCRIPTION
When running `bootstrap.py` as part of the deployment to prod, we are
getting an error:

```
Traceback (most recent call last):
  File \"bootstrap.py\", line 69, in ?
    exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
  File \"/usr/local/lib/python2.4/urllib2.py\", line 130, in urlopen
    return _opener.open(url, data)
  File \"/usr/local/lib/python2.4/urllib2.py\", line 358, in open
    response = self._open(req, data)
  File \"/usr/local/lib/python2.4/urllib2.py\", line 376, in _open
    '_open', req)
  File \"/usr/local/lib/python2.4/urllib2.py\", line 337, in _call_chain
    result = func(*args)
  File \"/usr/local/lib/python2.4/urllib2.py\", line 1021, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File \"/usr/local/lib/python2.4/urllib2.py\", line 996, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error (111, 'Connection refused')>
```

http://peak.telecommunity.com/ isn't online.

The thing is we actually already installed `ez_setup` and `setuptools` prior to
running `bootstrap.py` in ansible as part of installing python 2.4

`bootstrap.py` used `hasattr(pkg_resources, '_distribute')` but when I
tried to install `ez_setup` and `setuptools`, I don't see
`pkg_resources._distribute`.  This means that `bootstrap.py` always
tries to download and run `ez_setup.py`.